### PR TITLE
:hammer_and_wrench: WikiPathways svg url

### DIFF
--- a/R/wpplot.R
+++ b/R/wpplot.R
@@ -6,9 +6,11 @@
 #' @examples 
 #' wpplot('WP63_117935') 
 wpplot <- function(ID) {
-  url <- paste0('https://www.wikipathways.org//wpi/wpi.php?action=',
-                'downloadFile&type=svg&pwTitle=Pathway:',
-                ID)
+  url <- paste0('https://www.wikipathways.org/wikipathways-assets/pathways/',
+                ID,
+                '/', 
+                ID,
+                '.svg')
   svg <- yulab.utils::yread(url)
   if (!any(grepl('<svg', svg[1:10]))) {
     stop("fail to read online wiki pathway file")


### PR DESCRIPTION
The current code uses the old wpi.php url to get the WikiPathways svg. Adding the latest recommended path to extract the svg from WikiPathways.

- on Behalf of WikiPathways Dev team